### PR TITLE
chore: update dataset type texts

### DIFF
--- a/src/components/form-type/field-checkbox-type/field-checkbox.component.tsx
+++ b/src/components/form-type/field-checkbox-type/field-checkbox.component.tsx
@@ -50,7 +50,10 @@ const CheckboxFieldType: FC<Props> = ({
             onChange={handleChange}
           />
           <span className='form-check-label fdk-form-check-label mr-3' />
-          <span>{translationsService.translate(type.label)}</span>
+          <span>
+            {translationsService.translate(type.label)}{' '}
+            <small>({type.code})</small>
+          </span>
         </label>
       ))}
     </div>

--- a/src/services/translations/documents/helptexts.nb.js
+++ b/src/services/translations/documents/helptexts.nb.js
@@ -211,18 +211,8 @@ Se spesifikasjonen <a href='https://data.norge.no/specification/dcat-ap-no/#Data
 * Dersom datasettet inneholder personopplysninger vil det være nyttig for bruker å se en eksempedata som viser en anonymisert rad i datasettet.`
   },
   Dataset_type: {
-    abstract: 'Refererer til EU publication office sine datasett-typer.',
-    description: `Velg "Data" dersom datasettbeskrivelsen omhandler fysisk representasjon eller sammenstilling av opplysninger
-
-Velg "Testdata" dersom datasettbeskrivelsen omhandler anonymiserte eller pseudonymiserte data for testformål
-
-Velg "Kodelister" dersom datasettbeskrivelsen omhandler tabeller hvor koder beskrives ved hjelp av relevant informasjon
-
-Velg "Taksonomi" dersom datasettbeskrivelsen omhandler en hierarkisk strukturering av begreper
-
-Velg "Tesauri" dersom datasettbeskrivelsen omhandler en hierarkisk og  assosiativ strukturering av begreper
-
-Se spesifikasjonen <a href='https://data.norge.no/specification/dcat-ap-no/#Datasett-type' target='_blank'><span>Datasett: type</span></a>`
+    abstract: 'Identifiserer datasettets type.',
+    description: `Verdiene referer til EU’s kontrollerte vokabular <a href='https://op.europa.eu/en/web/eu-vocabularies/concept-scheme/-/resource?uri=http://publications.europa.eu/resource/authority/dataset-type' target='_blank'><span>Dataset type</span></a>.`
   },
   Dataset_source: {
     abstract:


### PR DESCRIPTION
Hjelpetekstene ble litt feil etter forrige oppdatering. Ble enig med Øystein om å gå over til å bare peke til vakabularet til EU og å legge til faktisk kodeverdi ved siden av norske navnene, for å enklere kunne finne korrekt verdi i visningen til EU

Ser nå ut som dette:
![Screenshot 2024-08-09 at 08 49 57](https://github.com/user-attachments/assets/b5403317-3970-4b04-951f-0a75bb53f0c7)
